### PR TITLE
Fix download source link

### DIFF
--- a/rsvm.sh
+++ b/rsvm.sh
@@ -86,7 +86,7 @@ rsvm_install()
     echo "Sources for rust v$1 already downloaded ..."
   else
     echo -n "Downloading sources for rust v$1 ... "
-    wget -q "http://dl.rust-lang.org/dist/rust-$1.tar.gz"
+    wget -q "http://static.rust-lang.org/dist/rust-$1.tar.gz"
     echo "done"
   fi
 


### PR DESCRIPTION
Download link "http://dl.rust-lang.org" doesn' t work for Rust 0.6. So I changed the resource (dl.rust-lang.org -> static.rust-lang.org).
