### PR TITLE
change rsvm install method and some command implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,25 @@ A version manager for rust.
 ## Installation
 
 ```console
-curl https://raw.github.com/sdepold/rsvm/master/install.sh | sh
+curl -L https://raw.github.com/sdepold/rsvm/master/install.sh | sh
 ```
 
 or
 
 ```console
 wget -qO- https://raw.github.com/sdepold/rsvm/master/install.sh | sh
+```
+
+### for fish-shell users
+
+```console
+ln -s ~/.rsvm/rsvm.fish ~/.config/fish/functions
+```
+
+or
+
+```console
+echo "source ~/.rsvm/rsvm.fish" >> ~/.config/fish/config.fish
 ```
 
 ## Usage
@@ -24,18 +36,18 @@ rsvm --help
 rsvm -h
 ```
 
-Download and install a &lt;version&gt;. &lt;version&gt; could be for example "0.4".
+Download and install a &lt;version&gt;. &lt;version&gt; could be for example "0.12.0".
 
 ```console
 rsvm install <version>
-e.g.: rsvm install 0.4
+e.g.: rsvm install 0.12.0
 ```
 
 Activate &lt;version&gt; for now and the future.
 
 ```console
 rsvm use <version>
-e.g. rsvm use 0.4
+e.g. rsvm use 0.12.0
 ```
 
 List all installed versions of rust. Choose the one that you like most.
@@ -45,17 +57,17 @@ rsvm ls
 rsvm list
 ```
 
-## Example: Install 0.4
+## Example: Install 0.12.0
 
 ```console
 curl https://raw.github.com/sdepold/rsvm/master/install.sh | sh
 source ~/.rsvm/rsvm.sh
-rsvm install 0.4
-rsvm use 0.4
+rsvm install 0.12.0
+rsvm use 0.12.0
 
 # you will now be able to access the rust binaries:
 ~ ∴ rustc -v
-rustc 0.4
+rustc 0.12.0
 host: x86_64-apple-darwin
 
 ~ ∴ cargo -h

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -124,19 +124,33 @@ function rsvm_install
   cd $current_dir
 end
 
-function rsvm
-  echo ''
-  echo 'Rust Version Manager'
-  echo '===================='
-  echo ''
+function rsvm_uninstall
+  set -l current_dir (pwd)
+  set -l v $argv[1]
+  if [ $v = (rsvm_current) ]
+    echo "rsvm: Cannot uninstall currently-active version, $v."
+    return
+  end
+  if not test -d "$RSVM_DIR/$v"
+    echo "$v version is not installed yet... "
+    return
+  end
+  echo "uninstall $v ..."
+  rm -rI "$RSVM_DIR/$v"
+end
 
+function rsvm
   switch "$argv[1]"
     case "help" "--help" "-h" ""
+      echo ''
+      echo 'Rust Version Manager'
+      echo '===================='
+      echo ''
       echo 'Usage:'
       echo ''
       echo '  rsvm help | --help | -h       Show this message.'
       echo '  rsvm install <version>        Download and install a <version>. <version> could be for example "0.11.0".'
-      # echo '  rsvm uninstall <version>      Uninstall a <version>.'
+      echo '  rsvm uninstall <version>      Uninstall a <version>.'
       echo '  rsvm use <version>            Activate <version> for now and the future.'
       echo '  rsvm ls | list                List all installed versions of rust.'
       echo ''
@@ -161,6 +175,10 @@ function rsvm
         echo "Example:"
         echo "  rsvm install 0.11.0"
       end
+    case "uninstall"
+      [ (count $argv) -ne 2 ]; and rsvm help; and return
+      set -l v $argv[2]
+      rsvm_uninstall "$v"
     case "ls" "list"
       rsvm_ls
     case use

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -157,7 +157,7 @@ function rsvm
       echo "Current version: $RSVM_VERSION"
     case "version" "--version" "-v"
       echo "v$RSVM_VERSION"
-    case "install"
+    case "install" "ins"
       [ (count $argv) -ne 2 ]; and rsvm help; and return
       set -l v $argv[2]
       #set -l opt $argv[3]
@@ -175,7 +175,7 @@ function rsvm
         echo "Example:"
         echo "  rsvm install 0.11.0"
       end
-    case "uninstall"
+    case "uninstall" "rm"
       [ (count $argv) -ne 2 ]; and rsvm help; and return
       set -l v $argv[2]
       rsvm_uninstall "$v"

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -64,6 +64,8 @@ function rsvm_mod_env
 
     if test $p[1] = PATH
       rsvm_set_path PATH $p[2..-1]
+    else if test $p[1] = LD_LIBRARY_PATH
+      rsvm_set_path LD_LIBRARY_PATH $p[2..-1]
     else if test $p[1] = MANPATH
       rsvm_set_path MANPATH $p[2..-1]
     end

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -37,7 +37,7 @@ function rsvm_use
 end
 
 function rsvm_current
-  echo (readlink .rsvm/current|tr "/" "\n" | tail -n 1)
+  echo (readlink $RSVM_DIR/current|tr "/" "\n" | tail -n 1)
 end
 
 function rsvm_ls

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -77,11 +77,10 @@ function rsvm_install_nightly
 
   rsvm_init_folder_structure $v
 
-  set -x CFG_PREFIX $RSVM_DIR/$v/dist
   curl https://static.rust-lang.org/rustup.sh | bash -s -- --prefix="$RSVM_DIR/$v/dist"
 
   echo ""
-  echo "And we are done. Have fun using rust v$v."
+  echo "And we are done. Have fun using rust $v."
 end
 
 function rsvm_install
@@ -98,11 +97,11 @@ function rsvm_install
       set platform $arch-unknown-linux-gnu
   end
 
-  if test -f "rust-$v.tar.gz"
+  if test -f "rust-$v-$platform.tar.gz"
     echo "Sources for rust v$v already downloaded ..."
   else
     echo -n "Downloading sources for rust v$v ... "
-    curl -o "rust-$v-$platform.tar.gz" "https://static.rust-lang.org/dist/rust-$v-$platform.tar.gz"
+    curl -s -o "rust-$v-$platform.tar.gz" "https://static.rust-lang.org/dist/rust-$v-$platform.tar.gz"
     echo "done"
   end
 
@@ -111,12 +110,12 @@ function rsvm_install
   else
     echo -n "Extracting source ... "
     tar -xzf "rust-$v-$platform.tar.gz"
+    mv "rust-$v-$platform" "rust-$v"
     echo "done"
   end
 
-  mv "rust-$v-$platform" "rust-$v"
   cd "rust-$v"
-
+  ls
   sh install.sh --prefix=$RSVM_DIR/v$v/dist
 
   echo ""
@@ -155,8 +154,10 @@ function rsvm
         echo "  rsvm install 0.11.0"
       else if [ "$v" = "nightly" ]
         rsvm_install_nightly
-      else if test -z (echo "$v" | sed -r 's/0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+      else if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
         rsvm_install "$v"
+      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
+        rsvm_install (echo "$v" | sed -r 's/^v//g')
       else
         # the version was defined in a the wrong format.
         echo "You defined a version of rust in a wrong format!"
@@ -175,9 +176,9 @@ function rsvm
         echo ""
         echo "Example:"
         echo "  rsvm use 0.11.0"
-      else if test -z (echo "$v" | sed -r 's/0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+      else if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
         rsvm_use "v$v"
-      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
         rsvm_use "$v"
       else if test -z (echo "$v" | sed -r 's/nightly\.[0-9]+//g')
         rsvm_use "$v"

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -115,8 +115,22 @@ function rsvm_install
   end
 
   cd "rust-$v"
-  ls
   sh install.sh --prefix=$RSVM_DIR/v$v/dist
+
+  if not test -f $RSVM_DIR/v$v/dist/bin/cargo
+    cd "$RSVM_DIR/v$v/src"
+    echo -n "Downloading sources for cargo nightly ... "
+    curl -s -o "cargo-nightly-$platform.tar.gz" "https://static.rust-lang.org/cargo-dist/cargo-nightly-$platform.tar.gz"
+    echo "done"
+
+    echo -n "Extracting source ... "
+    tar -xzf "cargo-nightly-$platform.tar.gz"
+    mv "cargo-nightly-x86_64-unknown-linux-gnu" "cargo-nightly"
+    echo "done"
+
+    cd "cargo-nightly"
+    sh install.sh --prefix=$RSVM_DIR/v$v/dist
+  end
 
   echo ""
   echo "And we are done. Have fun using rust v$v."

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -139,19 +139,15 @@ function rsvm
         echo ""
         echo "Example:"
         echo "  rsvm install 0.11.0"
-      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+      else if test -z (echo "$v" | sed -r 's/0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+        rsvm_install "$v"
+      else
         # the version was defined in a the wrong format.
         echo "You defined a version of rust in a wrong format!"
         echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
         echo ""
         echo "Example:"
         echo "  rsvm install 0.11.0"
-      else
-        #if [ "$opt" = "--dry" ]
-        #  echo "Would install rust v$v"
-        #else
-        rsvm_install "$v"
-        #end
       end
     case "ls" "list"
       rsvm_ls
@@ -163,17 +159,16 @@ function rsvm
         echo ""
         echo "Example:"
         echo "  rsvm use 0.11.0"
-      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+      else if test -z (echo "$v" | sed -r 's/0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+        rsvm_use "$v"
+      else
         # the version was defined in a the wrong format.
         echo "You defined a version of rust in a wrong format!"
         echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
         echo ""
         echo "Example:"
         echo "  rsvm use 0.11.0"
-      else
-        rsvm_use "$v"
       end
   end
-
   echo ''
 end

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -130,7 +130,7 @@ function rsvm
   echo '===================='
   echo ''
 
-  switch $argv[1]
+  switch "$argv[1]"
     case "help" "--help" "-h" ""
       echo 'Usage:'
       echo ''
@@ -144,15 +144,10 @@ function rsvm
     case "version" "--version" "-v"
       echo "v$RSVM_VERSION"
     case "install"
+      [ (count $argv) -ne 2 ]; and rsvm help; and return
       set -l v $argv[2]
       #set -l opt $argv[3]
-      if test -z "$v"
-        # whoops. no version found!
-        echo "Please define a version of rust!"
-        echo ""
-        echo "Example:"
-        echo "  rsvm install 0.11.0"
-      else if [ "$v" = "nightly" ]
+      if [ "$v" = "nightly" ]
         rsvm_install_nightly
       else if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
         rsvm_install "$v"
@@ -169,14 +164,9 @@ function rsvm
     case "ls" "list"
       rsvm_ls
     case use
+      [ (count $argv) -ne 2 ]; and rsvm help; and return
       set -l v $argv[2]
-      if test -z "$v"
-        # whoops. no version found!
-        echo "Please define a version of rust!"
-        echo ""
-        echo "Example:"
-        echo "  rsvm use 0.11.0"
-      else if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
+      if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
         rsvm_use "v$v"
       else if test -z (echo "$v" | sed -r 's/v0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
         rsvm_use "$v"

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -10,7 +10,12 @@ if not test -d "$RSVM_DIR"
 end
 
 if [ -e "$RSVM_DIR/current/dist/bin" ]
-  set -x PATH $RSVM_DIR/current/dist/bin $PATH
+  if not contains $RSVM_DIR/current/dist/bin $PATH
+      set -x PATH $RSVM_DIR/current/dist/bin $PATH
+  end
+  if not contains $RSVM_DIR/current/dist/lib $LD_LIBRARY_PATH
+      set -x LD_LIBRARY_PATH $RSVM_DIR/current/dist/lib $LD_LIBRARY_PATH
+  end
 end
 
 function rsvm_use

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -1,217 +1,93 @@
-# Rust Version Manager
-# ====================
-#
-# To use the rsvm command source this file from your bash profile.
+#? NVM wrapper. Félix Saparelli. Public Domain
+#> https://github.com/passcod/nvm-fish-wrapper
+#v 1.1.0
 
-set RSVM_VERSION "0.1.1"
-
-if not test -d "$RSVM_DIR"
-  set RSVM_DIR (dirname $argv[1])
-end
-
-if [ -e "$RSVM_DIR/current/dist/bin" ]
-  if not contains $RSVM_DIR/current/dist/bin $PATH
-      set -x PATH $RSVM_DIR/current/dist/bin $PATH
-  end
-  if not contains $RSVM_DIR/current/dist/lib $LD_LIBRARY_PATH
-      set -x LD_LIBRARY_PATH $RSVM_DIR/current/dist/lib $LD_LIBRARY_PATH
-  end
-end
-
-function rsvm_use
-  set -l v "$argv[1]"
-  if test -e "$RSVM_DIR/$v"
-    echo -n "Activating rust $v ... "
-
-    rm -rf $RSVM_DIR/current
-    ln -s $RSVM_DIR/$v $RSVM_DIR/current
-    source $RSVM_DIR/rsvm.fish
-
-    echo "done"
+function rsvm_set
+  if test (count $argv) -gt 1
+    #echo set: k: $argv[1] v: $argv[2..-1]
+    set -gx $argv[1] $argv[2..-1]
   else
-    echo "The specified version $v of rust is not installed..."
-    echo "You might want to install it with the following command:"
-    echo ""
-    echo "rsvm install $v"
+    #echo unset: k: $argv[1]
+    set -egx $argv[1]
   end
 end
 
-function rsvm_current
-  echo (readlink $RSVM_DIR/current|tr "/" "\n" | tail -n 1)
+function rsvm_split_env
+  set k (echo $argv | cut -d\= -f1)
+  set v (echo $argv | cut -d\= -f2-)
+  echo $k
+  echo $v
 end
 
-function rsvm_ls
-  set -l directories (find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \;|egrep "^(nightly\.[0-9]+|v[0-9]+\.[0-9]+\.?[0-9]*)"|sort)
+function rsvm_find_paths
+  echo $argv | grep -oE '[^:]+' | grep -w '.rsvm'
+end
 
-  echo "Installed versions:"
-  echo ""
+function rsvm_set_path
+  set k $argv[1]
+  set r $argv[2..-1]
 
-  if [ (echo "$directories" | grep -o "v" | wc -l) = 0 ]
-    echo '  -  None';
-  else
-    set -l curr (rsvm_current)
-    for line in (echo $directories | tr " " "\n")
-      if [ "$curr" = "$line" ]
-        echo "  =>  $line"
-      else
-        echo "  -   $line"
-      end
+  set newpath
+  for o in $$k
+    if echo $o | grep -qvw '.rsvm'
+      set newpath $newpath $o
     end
   end
+
+  set p (rsvm_find_paths $r | head -n1)
+  set newpath $p $newpath
+  rsvm_set $k $newpath
 end
 
-function rsvm_init_folder_structure
-  set -l v $argv[1]
-  echo -n "Creating the respective folders for rust $v ... "
+function rsvm_mod_env
+  set tmpnew $tmpdir/newenv
 
-  mkdir -p "$RSVM_DIR/$v/src"
-  mkdir -p "$RSVM_DIR/$v/dist"
+  bash -c "source ~/.rsvm/rsvm.sh && source $tmpold && rsvm $argv && export status=\$? && env > $tmpnew && exit \$status"
 
-  echo "done"
-end
-
-function rsvm_install_nightly
-  set -l current_dir (pwd)
-  set -l current (date "+%Y%m%d%H%M%S")
-  set -l v nightly.$current
-
-  rsvm_init_folder_structure $v
-
-  curl https://static.rust-lang.org/rustup.sh | bash -s -- --prefix="$RSVM_DIR/$v/dist"
-
-  echo ""
-  echo "And we are done. Have fun using rust $v."
-end
-
-function rsvm_install
-  set -l current_dir (pwd)
-  set -l v $argv[1]
-
-  rsvm_init_folder_structure v$v
-  cd "$RSVM_DIR/v$v/src"
-
-  set -l arch (uname -m)
-
-  switch (uname)
-    case Linux
-      set platform $arch-unknown-linux-gnu
+  set rsvmstat $status
+  if test $rsvmstat -gt 0
+    return $rsvmstat
   end
 
-  if test -f "rust-$v-$platform.tar.gz"
-    echo "Sources for rust v$v already downloaded ..."
-  else
-    echo -n "Downloading sources for rust v$v ... "
-    curl -s -o "rust-$v-$platform.tar.gz" "https://static.rust-lang.org/dist/rust-$v-$platform.tar.gz"
-    echo "done"
+  for e in (cat $tmpnew)
+    set p (rsvm_split_env $e)
+
+    if test (echo $p[1] | cut -d_ -f1) = rsvm
+      if test (count $p) -lt 2
+        rsvm_set $p[1] ''
+        continue
+      end
+
+      rsvm_set $p[1] $p[2..-1]
+      continue
+    end
+
+    if test $p[1] = PATH
+      rsvm_set_path PATH $p[2..-1]
+    else if test $p[1] = MANPATH
+      rsvm_set_path MANPATH $p[2..-1]
+    end
   end
 
-  if test -e "rust-$v"
-    echo "Sources for rust v$v already extracted ..."
-  else
-    echo -n "Extracting source ... "
-    tar -xzf "rust-$v-$platform.tar.gz"
-    mv "rust-$v-$platform" "rust-$v"
-    echo "done"
-  end
-
-  cd "rust-$v"
-  sh install.sh --prefix=$RSVM_DIR/v$v/dist
-
-  if not test -f $RSVM_DIR/v$v/dist/bin/cargo
-    cd "$RSVM_DIR/v$v/src"
-    echo -n "Downloading sources for cargo nightly ... "
-    curl -s -o "cargo-nightly-$platform.tar.gz" "https://static.rust-lang.org/cargo-dist/cargo-nightly-$platform.tar.gz"
-    echo "done"
-
-    echo -n "Extracting source ... "
-    tar -xzf "cargo-nightly-$platform.tar.gz"
-    mv "cargo-nightly-x86_64-unknown-linux-gnu" "cargo-nightly"
-    echo "done"
-
-    cd "cargo-nightly"
-    sh install.sh --prefix=$RSVM_DIR/v$v/dist
-  end
-
-  echo ""
-  echo "And we are done. Have fun using rust v$v."
-
-  cd $current_dir
-end
-
-function rsvm_uninstall
-  set -l current_dir (pwd)
-  set -l v $argv[1]
-  if [ $v = (rsvm_current) ]
-    echo "rsvm: Cannot uninstall currently-active version, $v."
-    return
-  end
-  if not test -d "$RSVM_DIR/$v"
-    echo "$v version is not installed yet... "
-    return
-  end
-  echo "uninstall $v ..."
-  rm -rI "$RSVM_DIR/$v"
+  return $rsvmstat
 end
 
 function rsvm
-  switch "$argv[1]"
-    case "help" "--help" "-h" ""
-      echo ''
-      echo 'Rust Version Manager'
-      echo '===================='
-      echo ''
-      echo 'Usage:'
-      echo ''
-      echo '  rsvm help | --help | -h       Show this message.'
-      echo '  rsvm install <version>        Download and install a <version>. <version> could be for example "0.11.0".'
-      echo '  rsvm uninstall <version>      Uninstall a <version>.'
-      echo '  rsvm use <version>            Activate <version> for now and the future.'
-      echo '  rsvm ls | list                List all installed versions of rust.'
-      echo ''
-      echo "Current version: $RSVM_VERSION"
-    case "version" "--version" "-v"
-      echo "v$RSVM_VERSION"
-    case "install" "ins"
-      [ (count $argv) -ne 2 ]; and rsvm help; and return
-      set -l v $argv[2]
-      #set -l opt $argv[3]
-      if [ "$v" = "nightly" ]
-        rsvm_install_nightly
-      else if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
-        rsvm_install "$v"
-      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
-        rsvm_install (echo "$v" | sed -r 's/^v//g')
-      else
-        # the version was defined in a the wrong format.
-        echo "You defined a version of rust in a wrong format!"
-        echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
-        echo ""
-        echo "Example:"
-        echo "  rsvm install 0.11.0"
-      end
-    case "uninstall" "rm"
-      [ (count $argv) -ne 2 ]; and rsvm help; and return
-      set -l v $argv[2]
-      rsvm_uninstall "$v"
-    case "ls" "list"
-      rsvm_ls
-    case use
-      [ (count $argv) -ne 2 ]; and rsvm help; and return
-      set -l v $argv[2]
-      if test -z (echo "$v" | sed -r 's/0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
-        rsvm_use "v$v"
-      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[0-9]+|[0-9]+\.[0-9]+)//g')
-        rsvm_use "$v"
-      else if test -z (echo "$v" | sed -r 's/nightly\.[0-9]+//g')
-        rsvm_use "$v"
-      else
-        # the version was defined in a the wrong format.
-        echo "You defined a version of rust in a wrong format!"
-        echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
-        echo ""
-        echo "Example:"
-        echo "  rsvm use 0.11.0"
-      end
+  set -g tmpdir (mktemp -d 2>/dev/null; or mktemp -d -t 'rsvm-wrapper') # Linux || OS X
+  set -g tmpold $tmpdir/oldenv
+  env | grep -E '^((rsvm|NODE)_|(MAN)?PATH=)' > $tmpold
+
+  set -l arg1 $argv[1]
+  if echo $arg1 | grep -qE '^(use|install|deactivate)$'
+    rsvm_mod_env $argv
+    set s $status
+  else if test $arg1 = 'unload'
+    functions -e (functions | grep -E '^rsvm(_|$)')
+  else
+    bash -c "source ~/.rsvm/rsvm.sh && source $tmpold && rsvm $argv"
+    set s $status
   end
-  echo ''
+
+  rm -r $tmpdir
+  return $s
 end

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -1,0 +1,174 @@
+# Rust Version Manager
+# ====================
+#
+# To use the rsvm command source this file from your bash profile.
+
+set RSVM_VERSION "0.1.1"
+
+if not test -d "$RSVM_DIR"
+  set RSVM_DIR (dirname $argv[1])
+end
+
+if [ -e "$RSVM_DIR/current/dist/bin" ]
+  set -x PATH $RSVM_DIR/current/dist/bin $PATH
+end
+
+function rsvm_use
+  set -l v "$argv[1]"
+  if test -e "$RSVM_DIR/v$v"
+    echo -n "Activating rust v$v ... "
+
+    rm -rf $RSVM_DIR/current
+    ln -s $RSVM_DIR/v$v $RSVM_DIR/current
+    source $RSVM_DIR/rsvm.fish
+
+    echo "done"
+  else
+    echo "The specified version v$v of rust is not installed..."
+    echo "You might want to install it with the following command:"
+    echo ""
+    echo "rsvm install $v"
+  end
+end
+
+function rsvm_current
+  echo (readlink .rsvm/current|tr "/" "\n" | tail -n 1)
+end
+
+function rsvm_ls
+  set -l directories (find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \;|egrep "^v[0-9]+\.[0-9]+\.?[0-9]*")
+
+  echo "Installed versions:"
+  echo ""
+
+  if [ (echo "$directories" | grep -o "v" | wc -l) = 0 ]
+    echo '  -  None';
+  else
+    set -l curr (rsvm_current)
+    for line in (echo $directories | tr " " "\n")
+      if [ "$curr" = "$line" ]
+        echo "  =>  $line"
+      else
+        echo "  -   $line"
+      end
+    end
+  end
+end
+
+function rsvm_init_folder_structure
+  set -l v $argv[1]
+  echo -n "Creating the respective folders for rust v$v ... "
+
+  mkdir -p "$RSVM_DIR/v$v/src"
+  mkdir -p "$RSVM_DIR/v$v/dist"
+
+  echo "done"
+end
+
+function rsvm_install
+  set -l current_dir (pwd)
+  set -l v $argv[1]
+
+  rsvm_init_folder_structure $v
+  cd "$RSVM_DIR/v$v/src"
+
+  set -l arch (uname -m)
+
+  switch (uname)
+    case Linux
+      set platform $arch-unknown-linux-gnu
+  end
+
+  if test -f "rust-$v.tar.gz"
+    echo "Sources for rust v$v already downloaded ..."
+  else
+    echo -n "Downloading sources for rust v$v ... "
+    curl -o "rust-$v-$platform.tar.gz" "https://static.rust-lang.org/dist/rust-$v-$platform.tar.gz"
+    echo "done"
+  end
+
+  if test -e "rust-$v"
+    echo "Sources for rust v$v already extracted ..."
+  else
+    echo -n "Extracting source ... "
+    tar -xzf "rust-$v-$platform.tar.gz"
+    echo "done"
+  end
+
+  mv "rust-$v-$platform" "rust-$v"
+  cd "rust-$v"
+
+  sh install.sh --prefix=$RSVM_DIR/v$v/dist
+
+  echo ""
+  echo "And we are done. Have fun using rust v$v."
+
+  cd $current_dir
+end
+
+function rsvm
+  echo ''
+  echo 'Rust Version Manager'
+  echo '===================='
+  echo ''
+
+  switch $argv[1]
+    case "help" "--help" "-h" ""
+      echo 'Usage:'
+      echo ''
+      echo '  rsvm help | --help | -h       Show this message.'
+      echo '  rsvm install <version>        Download and install a <version>. <version> could be for example "0.11.0".'
+      # echo '  rsvm uninstall <version>      Uninstall a <version>.'
+      echo '  rsvm use <version>            Activate <version> for now and the future.'
+      echo '  rsvm ls | list                List all installed versions of rust.'
+      echo ''
+      echo "Current version: $RSVM_VERSION"
+    case "version" "--version" "-v"
+      echo "v$RSVM_VERSION"
+    case "install"
+      set -l v $argv[2]
+      #set -l opt $argv[3]
+      if test -z "$v"
+        # whoops. no version found!
+        echo "Please define a version of rust!"
+        echo ""
+        echo "Example:"
+        echo "  rsvm install 0.11.0"
+      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+        # the version was defined in a the wrong format.
+        echo "You defined a version of rust in a wrong format!"
+        echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
+        echo ""
+        echo "Example:"
+        echo "  rsvm install 0.11.0"
+      else
+        #if [ "$opt" = "--dry" ]
+        #  echo "Would install rust v$v"
+        #else
+        rsvm_install "$v"
+        #end
+      end
+    case "ls" "list"
+      rsvm_ls
+    case use
+      set -l v $argv[2]
+      if test -z "$v"
+        # whoops. no version found!
+        echo "Please define a version of rust!"
+        echo ""
+        echo "Example:"
+        echo "  rsvm use 0.11.0"
+      else if test -z (echo "$v" | sed -r 's/v0\.(8\.[012345]|[1234567]\.[0-9]+)//g')
+        # the version was defined in a the wrong format.
+        echo "You defined a version of rust in a wrong format!"
+        echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
+        echo ""
+        echo "Example:"
+        echo "  rsvm use 0.11.0"
+      else
+        rsvm_use "$v"
+      end
+  end
+
+  echo ''
+end

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -25,6 +25,7 @@ rsvm_append_path()
 
 export PATH=$(rsvm_append_path $PATH $RSVM_DIR/current/dist/bin)
 export LD_LIBRARY_PATH=$(rsvm_append_path $LD_LIBRARY_PATH $RSVM_DIR/current/dist/lib)
+export MANPATH=$(rsvm_append_path $MANPATH $RSVM_DIR/current/dist/share/man)
 
 rsvm_use()
 {
@@ -138,6 +139,21 @@ rsvm_install()
 
   sh install.sh --prefix=$RSVM_DIR/$version/dist
 
+  if [ ! -f $RSVM_DIR/$version/dist/bin/cargo ]
+  then
+    cd "$RSVM_DIR/$version/src"
+    echo -n "Downloading sources for cargo nightly ... "
+    curl -o "cargo-nightly-$PLATFORM.tar.gz" "https://static.rust-lang.org/cargo-dist/cargo-nightly-$PLATFORM.tar.gz"
+    echo "done"
+
+    echo -n "Extracting source ... "
+    tar -xzf "cargo-nightly-$PLATFORM.tar.gz"
+    mv "cargo-nightly-$PLATFORM" "cargo-nightly"
+    echo "done"
+
+    cd "cargo-nightly"
+    sh install.sh --prefix=$RSVM_DIR/$version/dist
+  fi
   echo ""
   echo "And we are done. Have fun using rust $version."
 

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -18,17 +18,17 @@ fi
 
 rsvm_use()
 {
-  if [ -e "$RSVM_DIR/v$1" ]
+  if [ -e "$RSVM_DIR/$1" ]
   then
-    echo -n "Activating rust v$1 ... "
+    echo -n "Activating rust $1 ... "
 
     rm -rf $RSVM_DIR/current
-    ln -s $RSVM_DIR/v$1 $RSVM_DIR/current
+    ln -s $RSVM_DIR/$1 $RSVM_DIR/current
     source $RSVM_DIR/rsvm.sh
 
     echo "done"
   else
-    echo "The specified version v$1 of rust is not installed..."
+    echo "The specified version $1 of rust is not installed..."
     echo "You might want to install it with the following command:"
     echo ""
     echo "rsvm install $1"
@@ -43,7 +43,7 @@ rsvm_current()
 
 rsvm_ls()
 {
-  directories=`find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \;|egrep "^v\d+\.\d+\.?\d*"`
+  directories=`find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \;|egrep "^(nightly\.[0-9]+|v[0-9]+\.[0-9]+\.?[0-9]*)"|sort`
 
   echo "Installed versions:"
   echo ""
@@ -66,27 +66,47 @@ rsvm_ls()
 
 rsvm_init_folder_structure()
 {
-  echo -n "Creating the respective folders for rust v$1 ... "
+  echo -n "Creating the respective folders for rust $1 ... "
 
-  mkdir -p "$RSVM_DIR/v$1/src"
-  mkdir -p "$RSVM_DIR/v$1/dist"
+  mkdir -p "$RSVM_DIR/$1/src"
+  mkdir -p "$RSVM_DIR/$1/dist"
 
   echo "done"
+}
+
+rsvm_install_nightly() {
+  current_dir=`pwd`
+  current=`date "+%Y%m%d%H%M%S"`
+  v=nightly.$current
+
+  rsvm_init_folder_structure $v
+
+  curl https://static.rust-lang.org/rustup.sh | bash -s -- --prefix="$RSVM_DIR/$v/dist"
+
+  echo ""
+  echo "And we are done. Have fun using rust $v."
 }
 
 rsvm_install()
 {
   current_dir=`pwd`
 
-  rsvm_init_folder_structure $1
+  rsvm_init_folder_structure v$1
   cd "$RSVM_DIR/v$1/src"
 
-  if [ -f "rust-$1.tar.gz" ]
+  arch=`uname -m`
+  ostype=`uname`
+  if [ "$ostype" = "Linux" ]
+  then
+    platform=$arch-unknown-linux-gnu
+  fi
+
+  if [ -f "rust-$1-$platform.tar.gz" ]
   then
     echo "Sources for rust v$1 already downloaded ..."
   else
     echo -n "Downloading sources for rust v$1 ... "
-    wget -q "http://static.rust-lang.org/dist/rust-$1.tar.gz"
+    curl -s -o "rust-$1-$platform.tar.gz" "https://static.rust-lang.org/dist/rust-$1-$platform.tar.gz"
     echo "done"
   fi
 
@@ -95,29 +115,14 @@ rsvm_install()
     echo "Sources for rust v$1 already extracted ..."
   else
     echo -n "Extracting source ... "
-    tar -xzf "rust-$1.tar.gz"
+    tar -xzf "rust-$1-$platform.tar.gz"
+    mv "rust-$1-$platform" "rust-$1"
     echo "done"
   fi
 
   cd "rust-$1"
 
-  echo ""
-  echo "Configuring rust v$1. This will take some time. Grep a beer in the meantime."
-  echo ""
-
-  sleep 5
-
-  ./configure --prefix=$RSVM_DIR/v$1/dist --local-rust-root=$RSVM_DIR/v$1/dist
-
-  echo ""
-  echo "Still awake? Cool. Configuration is done."
-  echo ""
-  echo "Building rust v$1. This will take even more time. See you later ... "
-  echo ""
-
-  sleep 5
-
-  make && make install
+  sh install.sh --prefix=$RSVM_DIR/v$1/dist
 
   echo ""
   echo "And we are done. Have fun using rust v$1."
@@ -155,14 +160,15 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm install 0.4"
+      elif [ "$2" = "nightly" ]
+      then
+        rsvm_install_nightly
       elif ([[ "$2" =~ ^[0-9]+\.[0-9]+\.?[0-9]*$ ]])
       then
-        if [ "$3" = "--dry" ]
-        then
-          echo "Would install rust v$2"
-        else
-          rsvm_install "$2"
-        fi
+        rsvm_install "$2"
+      elif ([[ "$2" =~ ^v[0-9]+\.[0-9]+\.?[0-9]*$ ]])
+      then
+        rsvm_install `echo "$2" | sed -r 's/^v//g'`
       else
         # the version was defined in a the wrong format.
         echo "You defined a version of rust in a wrong format!"
@@ -184,6 +190,9 @@ rsvm()
         echo "Example:"
         echo "  rsvm use 0.4"
       elif ([[ "$2" =~ ^[0-9]+\.[0-9]+\.?[0-9]*$ ]])
+      then
+        rsvm_use "v$2"
+      elif ([[ "$2" =~ ^(nightly\.[0-9]+|v[0-9]+\.[0-9]+\.?[0-9]*)$ ]])
       then
         rsvm_use "$2"
       else

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -112,12 +112,19 @@ rsvm_install()
   cd $SRC
 
   local ARCH=`uname -m`
-  local OSTYPE=`uname`
-  local PLATFORM
-  if [ "$OSTYPE" = "Linux" ]
-  then
-    PLATFORM=$ARCH-unknown-linux-gnu
-  fi
+  local OSTYPE=`uname -s`
+  case $OSTYPE in
+    Linux)
+      PLATFORM=$ARCH-unknown-linux-gnu
+      ;;
+    Darwin)
+      PLATFORM=$ARCH-apple-darwin
+      ;;
+    *)
+      echo "rsvm: Not support this platform, $OSTYPE"
+      return
+      ;;
+  esac
 
   if [ -f "rust-$1-$PLATFORM.tar.gz" ]
   then
@@ -166,14 +173,22 @@ rsvm_ls_remote()
 {
   local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
   local ARCH=`uname -m`
-  local OSTYPE=`uname`
+  local OSTYPE=`uname -s`
   local VERSIONS
   local PLATFORM
-  if [ "$OSTYPE" = "Linux" ]
-  then
-    PLATFORM=$ARCH-unknown-linux-gnu
-    # TODO OTHER PLATFORM
-  fi
+  case $OSTYPE in
+    Linux)
+      PLATFORM=$ARCH-unknown-linux-gnu
+      ;;
+    Darwin)
+      PLATFORM=$ARCH-apple-darwin
+      ;;
+    *)
+      echo "rsvm: Not support this platform, $OSTYPE"
+      return
+      ;;
+  esac
+
   VERSIONS=$(curl -s http://static.rust-lang.org/dist/index.html -o - \
     | command egrep -o "rust-$VERSION_PATTERN-$PLATFORM.tar.gz" \
     | command uniq \

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -43,16 +43,19 @@ rsvm_current()
 
 rsvm_ls()
 {
-  directories=`find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \;|egrep "^(nightly\.[0-9]+|v[0-9]+\.[0-9]+\.?[0-9]*)"|sort`
+  local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
+  local DIRECTORIES=$(find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; \
+    | egrep ^$VERSION_PATTERN \
+    | sort)
 
   echo "Installed versions:"
   echo ""
 
-  if [ `grep -o "v" <<< "$directories" | wc -l` = 0 ]
+  if [ $(echo $DIRECTORIES | wc -l) = 0 ]
   then
     echo '  -  None';
   else
-    for line in $(echo $directories | tr " " "\n")
+    for line in $(echo $DIRECTORIES | tr " " "\n")
     do
       if [ `rsvm_current` = "$line" ]
       then

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -130,6 +130,25 @@ rsvm_install()
   cd $current_dir
 }
 
+rsvm_ls_remote()
+{
+  local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
+  ARCH=`uname -m`
+  OSTYPE=`uname`
+  local VERSIONS
+  if [ "$OSTYPE" = "Linux" ]
+  then
+    PLATFORM=$ARCH-unknown-linux-gnu
+    # TODO OTHER PLATFORM
+  fi
+  VERSIONS=$(curl -s http://static.rust-lang.org/dist/index.html -o - \
+    | command egrep -o "rust-$VERSION_PATTERN-$PLATFORM.tar.gz" \
+    | command uniq \
+    | command egrep -o "$VERSION_PATTERN" \
+    | command sort)
+  echo $VERSIONS
+}
+
 rsvm()
 {
   echo ''
@@ -146,6 +165,7 @@ rsvm()
       # echo '  rsvm uninstall <version>      Uninstall a <version>.'
       echo '  rsvm use <version>            Activate <version> for now and the future.'
       echo '  rsvm ls | list                List all installed versions of rust.'
+      echo '  rsvm ls-remote                List remote versions available for install.'
       echo ''
       echo "Current version: $RSVM_VERSION"
       ;;
@@ -175,11 +195,14 @@ rsvm()
         echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
         echo ""
         echo "Example:"
-        echo "  rsvm install 0.4"
+        echo "  rsvm install 0.12"
       fi
       ;;
     ls|list)
       rsvm_ls
+      ;;
+    ls-remote)
+      rsvm_ls_remote
       ;;
     use)
       if [ -z "$2" ]

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -161,7 +161,26 @@ rsvm_ls_remote()
     | command uniq \
     | command egrep -o "$VERSION_PATTERN" \
     | command sort)
-  echo $VERSIONS
+  for VERSION in $VERSIONS;
+  do
+    echo $VERSION
+  done
+}
+
+rsvm_uninstall()
+{
+  if [ `rsvm_current` = "$1" ]
+  then
+    echo "rsvm: Cannot uninstall currently-active version, $1"
+    return
+  fi
+  if [ ! -d "$RSVM_DIR/$1" ]
+  then
+    echo "$! version is not installed yet... "
+    return
+  fi
+  echo "uninstall $1 ..."
+  rm -rI "$RSVM_DIR/$1"
 }
 
 rsvm()
@@ -178,8 +197,9 @@ rsvm()
       echo 'Usage:'
       echo ''
       echo '  rsvm help | --help | -h       Show this message.'
-      echo '  rsvm install <version>        Download and install a <version>. <version> could be for example "0.12.0".'
-      # echo '  rsvm uninstall <version>      Uninstall a <version>.'
+      echo '  rsvm install <version>        Download and install a <version>.'
+      echo '                                <version> could be for example "0.12.0".'
+      echo '  rsvm uninstall <version>      Uninstall a <version>.'
       echo '  rsvm use <version>            Activate <version> for now and the future.'
       echo '  rsvm ls | list                List all installed versions of rust.'
       echo '  rsvm ls-remote                List remote versions available for install.'
@@ -235,6 +255,25 @@ rsvm()
         echo "  rsvm use 0.12.0"
       fi
       ;;
+    uninstall)
+      if [ -z "$2" ]
+      then
+        # whoops. no version found!
+        echo "Please define a version of rust!"
+        echo ""
+        echo "Example:"
+        echo "  rsvm use 0.12.0"
+      elif ([[ "$2" =~ ^$VERSION_PATTERN ]])
+      then
+        rsvm_uninstall "$2"
+      else
+        # the version was defined in a the wrong format.
+        echo "You defined a version of rust in a wrong format!"
+        echo "Please use either <major>.<minor> or <major>.<minor>.<patch>."
+        echo ""
+        echo "Example:"
+        echo "  rsvm uninstall 0.12.0"
+      fi
   esac
 
   echo ''

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -47,7 +47,12 @@ rsvm_use()
 
 rsvm_current()
 {
-  target=`echo echo $(readlink .rsvm/current)|tr "/" "\n"`
+  if [ ! -e $RSVM_DIR/current ]
+  then
+    echo "N/A"
+    return
+  fi
+  target=`echo $(readlink $RSVM_DIR/current)|tr "/" "\n"`
   echo ${target[@]} | awk '{print$NF}'
 }
 

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -11,10 +11,20 @@ then
   export RSVM_DIR=$(cd $(dirname ${BASH_SOURCE[0]:-$0}) && pwd)
 fi
 
-if [ -e "$RSVM_DIR/current/dist/bin" ]
-then
-  PATH=$RSVM_DIR/current/dist/bin:$PATH
-fi
+rsvm_append_path()
+{
+  local newpath
+  if [[ ":$1:" != *":$2:"* ]];
+  then
+    newpath="${1:+"$1:"}$2"
+  else
+    newpath="$1"
+  fi
+  echo $newpath
+}
+
+export PATH=$(rsvm_append_path $PATH $RSVM_DIR/current/dist/bin)
+export LD_LIBRARY_PATH=$(rsvm_append_path $LD_LIBRARY_PATH $RSVM_DIR/current/dist/lib)
 
 rsvm_use()
 {
@@ -208,10 +218,7 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm use 0.12.0"
-      elif ([[ "$2" =~ ^[0-9]+\.[0-9]+\.?[0-9]*$ ]])
-      then
-        rsvm_use "v$2"
-      elif ([[ "$2" =~ ^(nightly\.[0-9]+|v[0-9]+\.[0-9]+\.?[0-9]*)$ ]])
+      elif ([[ "$2" =~ ^$VERSION_PATTERN ]])
       then
         rsvm_use "$2"
       else

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -106,7 +106,10 @@ rsvm_install()
     version=$1
   fi
   rsvm_init_folder_structure $version
-  cd "$RSVM_DIR/$version/src"
+  local SRC="$RSVM_DIR/$version/src"
+  local DIST="$RSVM_DIR/$version/dist"
+
+  cd $SRC
 
   local ARCH=`uname -m`
   local OSTYPE=`uname`
@@ -135,13 +138,8 @@ rsvm_install()
     echo "done"
   fi
 
-  cd "rust-$1"
-
-  sh install.sh --prefix=$RSVM_DIR/$version/dist
-
-  if [ ! -f $RSVM_DIR/$version/dist/bin/cargo ]
+  if [ ! -f $SRC/rust-$1/bin/cargo ]
   then
-    cd "$RSVM_DIR/$version/src"
     echo -n "Downloading sources for cargo nightly ... "
     curl -o "cargo-nightly-$PLATFORM.tar.gz" "https://static.rust-lang.org/cargo-dist/cargo-nightly-$PLATFORM.tar.gz"
     echo "done"
@@ -151,9 +149,13 @@ rsvm_install()
     mv "cargo-nightly-$PLATFORM" "cargo-nightly"
     echo "done"
 
-    cd "cargo-nightly"
-    sh install.sh --prefix=$RSVM_DIR/$version/dist
+    cd "$SRC/cargo-nightly"
+    sh install.sh --prefix=$DIST
   fi
+
+  cd "$SRC/rust-$1"
+  sh install.sh --prefix=$DIST
+
   echo ""
   echo "And we are done. Have fun using rust $version."
 

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -61,13 +61,13 @@ rsvm_ls()
 {
   local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
   local DIRECTORIES=$(find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; \
-    | egrep ^$VERSION_PATTERN \
-    | sort)
+    | sort \
+    | egrep "^$VERSION_PATTERN")
 
   echo "Installed versions:"
   echo ""
 
-  if [ $(echo $DIRECTORIES | wc -l) = 0 ]
+  if [ $(egrep -o "^$VERSION_PATTERN" <<< "$DIRECTORIES" | wc -l) = 0 ]
   then
     echo '  -  None';
   else
@@ -218,7 +218,7 @@ rsvm_uninstall()
 
 rsvm()
 {
-  local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
+  local VERSION_PATTERN="(nightly(.[0-9]+)?|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
 
   echo ''
   echo 'Rust Version Manager'
@@ -252,7 +252,12 @@ rsvm()
         echo "  rsvm install 0.12.0"
       elif ([[ "$2" =~ ^$VERSION_PATTERN$ ]])
       then
-        rsvm_install "$2"
+        if [ "$3" = "--dry" ]
+        then
+          echo "Would install rust $2"
+        else
+          rsvm_install "$2"
+        fi
       else
         # the version was defined in a the wrong format.
         echo "You defined a version of rust in a wrong format!"
@@ -276,7 +281,7 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm use 0.12.0"
-      elif ([[ "$2" =~ ^$VERSION_PATTERN ]])
+      elif ([[ "$2" =~ ^$VERSION_PATTERN$ ]])
       then
         rsvm_use "$2"
       else
@@ -296,7 +301,7 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm use 0.12.0"
-      elif ([[ "$2" =~ ^$VERSION_PATTERN ]])
+      elif ([[ "$2" =~ ^$VERSION_PATTERN$ ]])
       then
         rsvm_uninstall "$2"
       else

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -94,6 +94,7 @@ rsvm_install()
 
   local ARCH=`uname -m`
   local OSTYPE=`uname`
+  local PLATFORM
   if [ "$OSTYPE" = "Linux" ]
   then
     PLATFORM=$ARCH-unknown-linux-gnu
@@ -131,9 +132,10 @@ rsvm_install()
 rsvm_ls_remote()
 {
   local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
-  ARCH=`uname -m`
-  OSTYPE=`uname`
+  local ARCH=`uname -m`
+  local OSTYPE=`uname`
   local VERSIONS
+  local PLATFORM
   if [ "$OSTYPE" = "Linux" ]
   then
     PLATFORM=$ARCH-unknown-linux-gnu

--- a/test/rsvm.sh.bats
+++ b/test/rsvm.sh.bats
@@ -8,7 +8,7 @@ export RSVM_DIR=`pwd`
 
 function cleanup()
 {
-  rm -rf `pwd`/v*
+  rm -rf `pwd`/0.*
   rm -rf `pwd`/current
 }
 
@@ -79,14 +79,14 @@ function assert()
 @test "'rsvm install 0.4' is not complaining" {
   cleanup
   run rsvm install 0.4 --dry
-  assert ${lines[2]} "Would install rust v0.4"
+  assert ${lines[2]} "Would install rust 0.4"
   cleanup
 }
 
 @test "'rsvm install 0.4.1' is not complaining" {
   cleanup
   run rsvm install 0.4.1 --dry
-  assert ${lines[2]} "Would install rust v0.4.1"
+  assert ${lines[2]} "Would install rust 0.4.1"
   cleanup
 }
 
@@ -113,8 +113,8 @@ function assert()
 
   run rsvm ls
   assert ${lines[2]} "Installed versions:"
-  assert ${lines[3]} "  -   v0.1"
-  assert ${lines[4]} "  -   v0.5"
+  assert ${lines[3]} "  -   0.1"
+  assert ${lines[4]} "  -   0.5"
 
   cleanup
 }
@@ -145,6 +145,6 @@ function assert()
   cleanup
   run rsvm_init_folder_structure 0.1
   run rsvm use 0.1
-  assert ${lines[2]} "Activating rust v0.1 ... done"
+  assert ${lines[2]} "Activating rust 0.1 ... done"
   cleanup
 }


### PR DESCRIPTION
now, rust-lang.org provide precompiled binaries. so I changed rsvm code. (but some feature losted. sorry)

add or fix features
* `install` command
  - if prebuilt package not contains `cargo`, also install this.
  - try install nightly, auto rename nightly.$timestamp
* `uninstall` command implement
* `ls-remote` command print all installable versions
* add fish shell wrapper

lost features
* version match rule change, so no more support `vX.Y.Z`. only can use `X.Y.Z`
* support platform reduced. now, only support linux and darwin platforms. but just tested linux. so darwin can be broken.