### PR TITLE
Support alpha2 and betas

### DIFF
--- a/rsvm.sh
+++ b/rsvm.sh
@@ -60,7 +60,7 @@ rsvm_current()
 
 rsvm_ls()
 {
-  local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
+  local VERSION_PATTERN="((nightly|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
   local DIRECTORIES=$(find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; \
     | sort \
     | egrep "^$VERSION_PATTERN")
@@ -172,7 +172,7 @@ rsvm_install()
 
 rsvm_ls_remote()
 {
-  local VERSION_PATTERN="(nightly|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
+  local VERSION_PATTERN="((nightly|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
   local ARCH=`uname -m`
   local OSTYPE=`uname -s`
   local VERSIONS
@@ -219,7 +219,7 @@ rsvm_uninstall()
 
 rsvm()
 {
-  local VERSION_PATTERN="(nightly(.[0-9]+)?|[0-9]\.[0-9]+(\.[0-9]+)?(-alpha)?)"
+  local VERSION_PATTERN="((nightly|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
 
   echo ''
   echo 'Rust Version Manager'


### PR DESCRIPTION
Update new version match patterns

before:
    > rsvm ls-remote

    Rust Version Manager
    ====================

    0.10
    0.11.0
    0.12.0
    1.0.0-alpha
    nightly

after:
    > rsvm ls-remote

    Rust Version Manager
    ====================

    0.10
    0.11.0
    0.12.0
    1.0.0-alpha
    1.0.0-alpha.2
    1.0.0-beta
    1.0.0-beta.2
    nightly