### PR TITLE
Fix use command's bug and cleanup code

### DIFF
--- a/rsvm.sh
+++ b/rsvm.sh
@@ -4,7 +4,7 @@
 # To use the rsvm command source this file from your bash profile.
 
 RSVM_VERSION="0.1.0"
-RSVM_VERSION_PATTERN="((nightly\.[0-9]*|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
+RSVM_VERSION_PATTERN="((nightly(\.[0-9]+)?|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
 
 # Auto detect the NVM_DIR
 if [ ! -d "$RSVM_DIR" ]
@@ -209,7 +209,7 @@ rsvm_uninstall()
   fi
   if [ ! -d "$RSVM_DIR/$1" ]
   then
-    echo "$! version is not installed yet... "
+    echo "$1 version is not installed yet..."
     return
   fi
   echo "uninstall $1 ..."
@@ -219,13 +219,12 @@ rsvm_uninstall()
 rsvm()
 {
 
-  echo ''
-  echo 'Rust Version Manager'
-  echo '===================='
-  echo ''
-
   case $1 in
     ""|help|--help|-h)
+      echo ''
+      echo 'Rust Version Manager'
+      echo '===================='
+      echo ''
       echo 'Usage:'
       echo ''
       echo '  rsvm help | --help | -h       Show this message.'
@@ -311,6 +310,9 @@ rsvm()
         echo "Example:"
         echo "  rsvm uninstall 0.12.0"
       fi
+      ;;
+    *)
+      rsvm
   esac
 
   echo ''

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -4,6 +4,7 @@
 # To use the rsvm command source this file from your bash profile.
 
 RSVM_VERSION="0.1.0"
+RSVM_VERSION_PATTERN="((nightly\.[0-9]*|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
 
 # Auto detect the NVM_DIR
 if [ ! -d "$RSVM_DIR" ]
@@ -60,15 +61,14 @@ rsvm_current()
 
 rsvm_ls()
 {
-  local VERSION_PATTERN="((nightly|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
   local DIRECTORIES=$(find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; \
     | sort \
-    | egrep "^$VERSION_PATTERN")
+    | egrep "^$RSVM_VERSION_PATTERN")
 
   echo "Installed versions:"
   echo ""
 
-  if [ $(egrep -o "^$VERSION_PATTERN" <<< "$DIRECTORIES" | wc -l) = 0 ]
+  if [ $(egrep -o "^$RSVM_VERSION_PATTERN" <<< "$DIRECTORIES" | wc -l) = 0 ]
   then
     echo '  -  None';
   else
@@ -172,7 +172,6 @@ rsvm_install()
 
 rsvm_ls_remote()
 {
-  local VERSION_PATTERN="((nightly|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
   local ARCH=`uname -m`
   local OSTYPE=`uname -s`
   local VERSIONS
@@ -191,9 +190,9 @@ rsvm_ls_remote()
   esac
 
   VERSIONS=$(curl -s http://static.rust-lang.org/dist/index.html -o - \
-    | command egrep -o "rust-$VERSION_PATTERN-$PLATFORM.tar.gz" \
+    | command egrep -o "rust-$RSVM_VERSION_PATTERN-$PLATFORM.tar.gz" \
     | command uniq \
-    | command egrep -o "$VERSION_PATTERN" \
+    | command egrep -o "$RSVM_VERSION_PATTERN" \
     | command sort)
   for VERSION in $VERSIONS;
   do
@@ -219,7 +218,6 @@ rsvm_uninstall()
 
 rsvm()
 {
-  local VERSION_PATTERN="((nightly|[0-9]+\.[0-9]+(\.[0-9]+)?)(-(alpha|beta)(\.[0-9]*)?)?)"
 
   echo ''
   echo 'Rust Version Manager'
@@ -251,7 +249,7 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm install 0.12.0"
-      elif ([[ "$2" =~ ^$VERSION_PATTERN$ ]])
+      elif ([[ "$2" =~ ^$RSVM_VERSION_PATTERN$ ]])
       then
         if [ "$3" = "--dry" ]
         then
@@ -282,7 +280,7 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm use 0.12.0"
-      elif ([[ "$2" =~ ^$VERSION_PATTERN$ ]])
+      elif ([[ "$2" =~ ^$RSVM_VERSION_PATTERN$ ]])
       then
         rsvm_use "$2"
       else
@@ -302,7 +300,7 @@ rsvm()
         echo ""
         echo "Example:"
         echo "  rsvm use 0.12.0"
-      elif ([[ "$2" =~ ^$VERSION_PATTERN$ ]])
+      elif ([[ "$2" =~ ^$RSVM_VERSION_PATTERN$ ]])
       then
         rsvm_uninstall "$2"
       else

--- a/test/rsvm.sh.bats
+++ b/test/rsvm.sh.bats
@@ -9,6 +9,7 @@ export RSVM_DIR=`pwd`
 function cleanup()
 {
   rm -rf `pwd`/0.*
+  rm -rf `pwd`/nightly*
   rm -rf `pwd`/current
 }
 
@@ -45,58 +46,58 @@ function cleanup()
 @test "'rsvm install' prints a notice that no version was defined" {
   cleanup
   run rsvm install
-  [ "${lines[2]}" = "Please define a version of rust!" ]
+  [ "${lines[0]}" = "Please define a version of rust!" ]
   cleanup
 }
 
 @test "'rsvm install 0.1.1.1.1' prints a notice that the format is wrong" {
   cleanup
   run rsvm install 0.1.1.1.1
-  [ "${lines[2]}" = "You defined a version of rust in a wrong format!" ]
+  [ "${lines[0]}" = "You defined a version of rust in a wrong format!" ]
   cleanup
 }
 
 @test "'rsvm install v0.4' prints a notice that the format is wrong" {
   cleanup
   run rsvm install v0.4
-  [ "${lines[2]}" = "You defined a version of rust in a wrong format!" ]
+  [ "${lines[0]}" = "You defined a version of rust in a wrong format!" ]
   cleanup
 }
 
 @test "'rsvm install 1' prints a notice that the format is wrong" {
   cleanup
   run rsvm install 1
-  [ "${lines[2]}" = "You defined a version of rust in a wrong format!" ]
+  [ "${lines[0]}" = "You defined a version of rust in a wrong format!" ]
   cleanup
 }
 
 @test "'rsvm install 0.4' is not complaining" {
   cleanup
   run rsvm install 0.4 --dry
-  [ "${lines[2]}" = "Would install rust 0.4" ]
+  [ "${lines[0]}" = "Would install rust 0.4" ]
   cleanup
 }
 
 @test "'rsvm install 0.4.1' is not complaining" {
   cleanup
   run rsvm install 0.4.1 --dry
-  [ "${lines[2]}" = "Would install rust 0.4.1" ]
+  [ "${lines[0]}" = "Would install rust 0.4.1" ]
   cleanup
 }
 
 @test "'rsvm ls' will return an empty list if no versions have been installed" {
   cleanup
   run rsvm ls
-  [ "${lines[2]}" = "Installed versions:" ]
-  [ "${lines[3]}" = "  -  None" ]
+  [ "${lines[0]}" = "Installed versions:" ]
+  [ "${lines[1]}" = "  -  None" ]
   cleanup
 }
 
 @test "'rsvm list' will return an empty list if no versions have been installed" {
   cleanup
   run rsvm list
-  [ "${lines[2]}" = "Installed versions:" ]
-  [ "${lines[3]}" = "  -  None" ]
+  [ "${lines[0]}" = "Installed versions:" ]
+  [ "${lines[1]}" = "  -  None" ]
   cleanup
 }
 
@@ -106,9 +107,9 @@ function cleanup()
   run rsvm_init_folder_structure 0.5
 
   run rsvm ls
-  [ "${lines[2]}" = "Installed versions:" ]
-  [ "${lines[3]}" = "  -   0.1" ]
-  [ "${lines[4]}" = "  -   0.5" ]
+  [ "${lines[0]}" = "Installed versions:" ]
+  [ "${lines[1]}" = "  -   0.1" ]
+  [ "${lines[2]}" = "  -   0.5" ]
 
   cleanup
 }
@@ -116,22 +117,22 @@ function cleanup()
 @test "'rsvm use' will notify the user about missing version" {
   cleanup
   run rsvm use
-  [ "${lines[2]}" = "Please define a version of rust!" ]
+  [ "${lines[0]}" = "Please define a version of rust!" ]
   cleanup
 }
 
 @test "'rsvm use' will notify the user about a malformed version" {
   cleanup
   run rsvm use 1.1.1.1.1
-  [ "${lines[2]}" = "You defined a version of rust in a wrong format!" ]
+  [ "${lines[0]}" = "You defined a version of rust in a wrong format!" ]
   cleanup
 }
 
 @test "'rsvm use 0.1' will notify the user about a not installed version" {
   cleanup
   run rsvm use 0.1
-  [ "${lines[3]}" = "You might want to install it with the following command:" ]
-  [ "${lines[4]}" = "rsvm install 0.1" ]
+  [ "${lines[1]}" = "You might want to install it with the following command:" ]
+  [ "${lines[2]}" = "rsvm install 0.1" ]
   cleanup
 }
 
@@ -139,6 +140,45 @@ function cleanup()
   cleanup
   run rsvm_init_folder_structure 0.1
   run rsvm use 0.1
-  [ "${lines[2]}" = "Activating rust 0.1 ... done" ]
+  [ "${lines[0]}" = "Activating rust 0.1 ... done" ]
+  cleanup
+}
+
+@test "'rsvm use nightly' will activate the right version" {
+  cleanup
+  run rsvm_init_folder_structure nightly.1234
+  run rsvm use nightly.1234
+  [ "${lines[0]}" = "Activating rust nightly.1234 ... done" ]
+  cleanup
+}
+
+@test "'rsvm uninstall 0.1' will notify the user about a not installed version" {
+  cleanup
+  run rsvm uninstall 0.1
+  [ "${lines[0]}" = "0.1 version is not installed yet..." ]
+  cleanup
+}
+
+@test "'rsvm uninstall 0.1' will notify the user about current using version" {
+  cleanup
+  run rsvm_init_folder_structure 0.1
+  run rsvm use 0.1
+  run rsvm uninstall 0.1
+  [ "${lines[0]}" = "rsvm: Cannot uninstall currently-active version, 0.1" ]
+  cleanup
+}
+
+function uninstall() {
+  # FIXME: current bats not support stdin.
+  echo "yes" | rsvm uninstall $1
+}
+
+@test "'rsvm uninstall 0.1' will remove installed version" {
+  cleanup
+  run rsvm_init_folder_structure 0.1
+  uninstall 0.1
+  run rsvm ls
+  [ "${lines[0]}" = "Installed versions:" ]
+  [ "${lines[1]}" = "  -  None" ]
   cleanup
 }


### PR DESCRIPTION
mistake #5, it cause broken use nightly version match.

also this patch contains these;
- extract version pattern variable
- input wrong arguments to redirect help
- only `rsvm help` can print rsvm header message; also fix tests
- fix mistype char (`$!` to `$1`) in rsvm_uninstall
- add new unittests; use nightly, uninstall