### PR TITLE
Fixed script issue in the zsh

### DIFF
--- a/rsvm.sh
+++ b/rsvm.sh
@@ -61,7 +61,7 @@ rsvm_current()
 
 rsvm_ls()
 {
-  local DIRECTORIES=$(find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; \
+  DIRECTORIES=$(find $RSVM_DIR -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; \
     | sort \
     | egrep "^$RSVM_VERSION_PATTERN")
 


### PR DESCRIPTION
in zsh `rsvm ls` throws `rsvm_ls:local:2: not valid in this context: nightly.20150626160230`