### PR TITLE
rsvm.sh: Fix wrong rsvm_current action in the zsh

### DIFF
--- a/rsvm.sh
+++ b/rsvm.sh
@@ -55,7 +55,7 @@ rsvm_current()
     echo "N/A"
     return
   fi
-  target=`echo $(readlink $RSVM_DIR/current)|tr "/" "\n"`
+  target=`echo $(readlink $RSVM_DIR/current|tr "/" "\n")`
   echo ${target[@]} | awk '{print$NF}'
 }
 


### PR DESCRIPTION
before:

    % rsvm ls
    Installed versions:

    rsvm_ls:16: condition expected: home
      -   1.0.0

after:

    % rsvm ls
    Installed versions:

      =>  1.0.0

zsh and bash works little differently, if we activated rsvm,
`rsvm_current` in zsh will print multiple line.