### PR TITLE
Support staging channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ List all versions of rust that are available for installation.
 rsvm ls-remote
 ```
 
+Print a channel version of rust that is available for installation.
+
+```console
+rsvm ls-channel stable
+```
+
 ## Example: Install 0.12.0
 
 ```console


### PR DESCRIPTION
- Add new command `ls-channel`;
  It will print current `stable` or `staging` channel's version
- Support install `staging` channel; `rsvm install 1.2.0-rc`
- Extract platform variables
- Fix always download cargo nightly