### PR TITLE
OS X `rm -I` is `-i` for interactive rm

### DIFF
--- a/rsvm.sh
+++ b/rsvm.sh
@@ -257,7 +257,15 @@ rsvm_uninstall()
     return
   fi
   echo "uninstall $1 ..."
-  rm -rI "$RSVM_DIR/$1"
+
+  case $RSVM_OSTYPE in
+    Darwin)
+      rm -ri "$RSVM_DIR/$1"
+      ;;
+    *)
+      rm -rI "$RSVM_DIR/$1"
+      ;;
+  esac
 }
 
 rsvm()


### PR DESCRIPTION
- addresses this by checking the OS and using `-i` on Darwin
- fix #15