### PR TITLE
rsvm.sh: New suboption `--with-rustc-source` for `install` command

### DIFF
--- a/rsvm.fish
+++ b/rsvm.fish
@@ -70,6 +70,8 @@ function rsvm_mod_env
       rsvm_set_path DYLD_LIBRARY_PATH $p[2..-1]
     else if test $p[1] = MANPATH
       rsvm_set_path MANPATH $p[2..-1]
+    else if test $p[1] = RUST_SRC_PATH
+      rsvm_set_path RUST_SRC_PATH $p[2..-1]
     end
   end
 


### PR DESCRIPTION
Resolve #24

Some useful commands required `rustc` source code and `RUST_SRC_PATH`
env variable.

New option will download sourcecode and extract to version directory