### PR TITLE
RUST_SRC_PATH only can set after install source code

### DIFF
--- a/rsvm.fish
+++ b/rsvm.fish
@@ -49,6 +49,8 @@ function rsvm_mod_env
     return $rsvmstat
   end
 
+  rsvm_set RUST_SRC_PATH
+
   for e in (cat $tmpnew)
     set p (rsvm_split_env $e)
 
@@ -71,7 +73,7 @@ function rsvm_mod_env
     else if test $p[1] = MANPATH
       rsvm_set_path MANPATH $p[2..-1]
     else if test $p[1] = RUST_SRC_PATH
-      rsvm_set_path RUST_SRC_PATH $p[2..-1]
+      rsvm_set RUST_SRC_PATH $p[2..-1]
     end
   end
 
@@ -81,7 +83,7 @@ end
 function rsvm
   set -g tmpdir (mktemp -d 2>/dev/null; or mktemp -d -t 'rsvm-wrapper') # Linux || OS X
   set -g tmpold $tmpdir/oldenv
-  env | grep -E '^((rsvm|NODE)_|(MAN)?PATH=)' > $tmpold
+  env | grep -E '^((rsvm|RUST)_|(MAN)?PATH=)' > $tmpold
 
   set -l arg1 $argv[1]
   if echo $arg1 | grep -qE '^(use|install|deactivate)$'

--- a/rsvm.sh
+++ b/rsvm.sh
@@ -83,7 +83,13 @@ export PATH=$(rsvm_append_path $PATH $RSVM_DIR/current/dist/bin)
 export LD_LIBRARY_PATH=$(rsvm_append_path $LD_LIBRARY_PATH $RSVM_DIR/current/dist/lib)
 export DYLD_LIBRARY_PATH=$(rsvm_append_path $DYLD_LIBRARY_PATH $RSVM_DIR/current/dist/lib)
 export MANPATH=$(rsvm_append_path $MANPATH $RSVM_DIR/current/dist/share/man)
-export RUST_SRC_PATH=$(rsvm_append_path $RUST_SRC_PATH $RSVM_DIR/current/src/rustc-source/src)
+export RSVM_SRC_PATH="$RSVM_DIR/current/src/rustc-source/src"
+if [ -e "$RSVM_SRC_PATH" ]
+then
+  export RUST_SRC_PATH="$RSVM_SRC_PATH"
+else
+  unset RUST_SRC_PATH
+fi
 
 rsvm_use()
 {


### PR DESCRIPTION
If not installed, rsvm will unset RUST_SET_PATH environ variable
This patch will help #27 problems