### PR TITLE
Improve rustup and cargo support

### DIFF
--- a/rsvm.fish
+++ b/rsvm.fish
@@ -74,6 +74,10 @@ function rsvm_mod_env
       rsvm_set_path MANPATH $p[2..-1]
     else if test $p[1] = RUST_SRC_PATH
       rsvm_set RUST_SRC_PATH $p[2..-1]
+    else if test $p[1] = CARGO_HOME
+      rsvm_set CARGO_HOME $p[2..-1]
+    else if test $p[1] = RUSTUP_HOME
+      rsvm_set RUSTUP_HOME $p[2..-1]
     end
   end
 

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -34,8 +34,9 @@ function rsvm_set_path
     end
   end
 
-  set p (rsvm_find_paths $r | head -n1)
-  set newpath $p $newpath
+  for p in (rsvm_find_paths $r)
+    set newpath $p $newpath
+  end
   rsvm_set $k $newpath
 end
 


### PR DESCRIPTION
- support `rustup` command. but cannot use some feture like `rustup update`
- override `CARGO_HOME` instead `~/.cargo`
