### PR TITLE
Fix fish functions error

### DIFF
--- a/rsvm.fish
+++ b/rsvm.fish
@@ -88,7 +88,7 @@ end
 function rsvm
   set -g tmpdir (mktemp -d 2>/dev/null; or mktemp -d -t 'rsvm-wrapper') # Linux || OS X
   set -g tmpold $tmpdir/oldenv
-  env | grep -E '^((rsvm|RUST)_|(MAN)?PATH=)' | sed -E 's/\\\\? /\\\\ /g' > $tmpold
+  env | grep -E '^((rsvm|RUST)_|(MAN)?PATH=)' | sed -E 's/\\\\?([ ()])/\\\\\\1/g' > $tmpold
 
   set -l arg1 $argv[1]
   if echo $arg1 | grep -qE '^(use|install|deactivate)$'

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -88,7 +88,7 @@ end
 function rsvm
   set -g tmpdir (mktemp -d 2>/dev/null; or mktemp -d -t 'rsvm-wrapper') # Linux || OS X
   set -g tmpold $tmpdir/oldenv
-  env | grep -E '^((rsvm|RUST)_|(MAN)?PATH=)' > $tmpold
+  env | grep -E '^((rsvm|RUST)_|(MAN)?PATH=)' | sed -E 's/\\\\? /\\\\ /g' > $tmpold
 
   set -l arg1 $argv[1]
   if echo $arg1 | grep -qE '^(use|install|deactivate)$'

--- a/rsvm.fish
+++ b/rsvm.fish
@@ -94,7 +94,7 @@ function rsvm
   if echo $arg1 | grep -qE '^(use|install|deactivate)$'
     rsvm_mod_env $argv
     set s $status
-  else if test $arg1 = 'unload'
+  else if test $arg1 = 'unload' 2>/dev/null
     functions -e (functions | grep -E '^rsvm(_|$)')
   else
     bash -c "source ~/.rsvm/rsvm.sh && source $tmpold && rsvm $argv"


### PR DESCRIPTION
// I am not good at English, so please let me know if it's strange...
I fixed fish function "rsvm", please merge if you do not mind.
- Ignore test command's warning when function has no arguments
- Fix error when env's output contains white space (i.e. OSX: `/Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin`)

Thank you for your great project!

----

// 英語が苦手なのでおかしかったら教えてほしい…
fish functionsの"rsvm"を修正したので、よかったらマージしてください。
- 引数がないときにtestが出力する警告を無視
- OSXで空白を含むPATHを設定しているときにエラーになる

素晴らしいプロジェクトをありがとう！
